### PR TITLE
AU-749 case insensitivity in filters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ coverage
 *.tar.*
 *.tgz
 .DS_Store
+.idea

--- a/lib/filters/equality_filter.js
+++ b/lib/filters/equality_filter.js
@@ -9,7 +9,6 @@ var parents = require('ldap-filter');
 var Filter = require('./filter');
 
 
-
 ///--- API
 
 function EqualityFilter(options) {
@@ -26,20 +25,11 @@ EqualityFilter.prototype.matches = function (target, strictAttrCase) {
   var tv = parents.getAttrValue(target, this.attribute, strictAttrCase);
   var value = this.value;
 
-  if (this.attribute.toLowerCase() === 'objectclass') {
-    /*
-     * Perform case-insensitive match for objectClass since nearly every LDAP
-     * implementation behaves in this manner.
-     */
-    value = value.toLowerCase();
-    return parents.testValues(function (v) {
-      return value === v.toLowerCase();
-    }, tv);
-  } else {
-    return parents.testValues(function (v) {
-      return value === v;
-    }, tv);
-  }
+  // OneLogin-specific changes:
+  // We ignore case for all equality filters used in VLDAP
+  return parents.testValues(function (v) {
+    return value.toLowerCase() === v.toLowerCase();
+  }, tv);
 };
 
 

--- a/test/filters/eq.test.js
+++ b/test/filters/eq.test.js
@@ -196,3 +196,18 @@ test('GH-277 objectClass should be case-insensitive', function (t) {
   t.ok(!f.matches({ objectclass: 'matchless' }));
   t.end();
 });
+
+// OneLogin VLDAP requirements below
+test('All attributes must be case insensitive', function (t) {
+  var f = new EqualityFilter({
+    attribute: 'mail',
+    value: 'test@test.com'
+  });
+  t.ok(f);
+  t.ok(f.matches({ mail: 'test@test.com' }));
+  t.ok(f.matches({ mail: 'test@TEST.com' }));
+  t.ok(f.matches({ mail: 'teSt@test.com' }));
+  t.ok(f.matches({ MAIL: 'teSt@test.com' }));
+  t.ok(!f.matches({ mail: 'TESTTTTT@TEST.com' }));
+  t.end();
+});


### PR DESCRIPTION
## status
**READY**

## description
MAke vldap filter attributes and values case insensitive


## steps to test
`npm install`
`npm update`

Now do ldap searches with case insensitive filter values
`ldapsearch -H ldap://vldap-shadow01.onelogin.com -x -D "cn=1@1.cOm,ou=users,dc=sasanka-test,dc=onelogin,dc=com" -b "cn=1@1.com,ou=users,dc=sasanka-test,dc=onelogin,dc=com" -s base -w '1' "(Name=oNe 11)"` -> pass

`ldapsearch -H ldap://vldap-shadow01.onelogin.com -x -D "cn=1@1.cOm,ou=users,dc=sasanka-test,dc=onelogin,dc=com" -b "cn=1@1.com,ou=users,dc=sasanka-test,dc=onelogin,dc=com" -s base -w '1' "(Name=oNE 11)"` -> pass


`ldapsearch -H ldap://vldap-shadow01.onelogin.com -x -D "cn=1@1.cOm,ou=users,dc=sasanka-test,dc=onelogin,dc=com" -b "cn=1@1.com,ou=users,dc=sasanka-test,dc=onelogin,dc=com" -s base -w '1' "(Name=oNeee 111)"` -> should fail


## JIRA
https://onelogin2.atlassian.net/browse/AU-749


